### PR TITLE
Update `aput` and implement `aput_writes`

### DIFF
--- a/src/langgraph_checkpoint_firestore/firestoreSaver.py
+++ b/src/langgraph_checkpoint_firestore/firestoreSaver.py
@@ -293,8 +293,17 @@ class FirestoreSaver(BaseCheckpointSaver):
                 return
 
     async def aput(
-        self, config: RunnableConfig, checkpoint: Checkpoint
+        self, config: RunnableConfig, checkpoint: Checkpoint, metadata: CheckpointMetadata, new_versions: ChannelVersions
     ) -> RunnableConfig:
+        print("aput", config, checkpoint, metadata, new_versions)
         return await asyncio.get_running_loop().run_in_executor(
-            None, self.put, config, checkpoint
+            None, self.put, config, checkpoint, metadata, new_versions
+        )
+
+    async def aput_writes(
+        self, config: RunnableConfig, writes: List[Tuple[str, Any]], task_id: str
+    ) -> None:
+        print("aput_writes", config, writes, task_id)
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.put_writes, config, writes, task_id
         )


### PR DESCRIPTION
I'm using this FirestoreSaver as the checkpointer for a supervisor agent from [langgraph-supervisor](https://github.com/langchain-ai/langgraph-supervisor-py).


```
from langgraph_supervisor import create_supervisor
...
    supervisor = create_supervisor(
        model=init_chat_model("openai:gpt-4.1"),
        agents=[report_builder_agent],
        prompt=prompt,
        add_handoff_back_messages=True,
        output_mode="full_history",
        supervisor_name="supervisor",
        response_format=SupervisorResponse.model_json_schema(),
    ).compile(
        checkpointer=checkpointer,
    )
```

However, when invoking the graph asynchronously with `supervisor.ainvoke(...)` I get this original error:

```
FirestoreSaver.aput() takes 3 positional arguments but 5 were given
```

And then after updating the signature to support the additional arguments, I get another emergent error:

```
ERROR:app.routes.public:Error processing genie search for tenant 1337: Traceback (most recent call last):
  File "/Users/alan/Code2/backend/genie-reports/app/routes/public.py", line 73, in genie_search
    res = await supervisor.ainvoke(
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 2788, in ainvoke
    async for chunk in self.astream(
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 2655, in astream
    async for _ in runner.atick(
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph_supervisor/supervisor.py", line 106, in acall_agent
    output = await agent.ainvoke(
             ^^^^^^^^^^^^^^^^^^^^
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 2788, in ainvoke
    async for chunk in self.astream(
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 2596, in astream
    async with AsyncPregelLoop(
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/loop.py", line 1393, in __aexit__
    return await exit_task
           ^^^^^^^^^^^^^^^
  File "/Users/alan/.pyenv/versions/3.11.9/lib/python3.11/contextlib.py", line 745, in __aexit__
    raise exc_details[1]
  File "/Users/alan/.pyenv/versions/3.11.9/lib/python3.11/contextlib.py", line 728, in __aexit__
    cb_suppress = await cb(*exc_details)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/pregel/executor.py", line 209, in __aexit__
    raise exc
  File "/Users/alan/.pyenv/versions/genie-3.11.9/lib/python3.11/site-packages/langgraph/checkpoint/base/__init__.py", line 427, in aput_writes
    raise NotImplementedError
NotImplementedError
```

So this PR also implements the missing `aput_writes` and the agent runs and checkpoints without problem. 🙏 